### PR TITLE
Make errors and output JSON-serialized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ default = ["console_error_panic_hook"]
 [dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.14"
+serde = {version = "1.0.110", features = ["derive"]}
+serde_json = "1.0.56"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -28,6 +30,7 @@ console_error_panic_hook = {version = "0.1.6", optional = true}
 wee_alloc = {version = "0.4.5", optional = true}
 
 nu-cli = {git = "https://github.com/jonathandturner/nushell.git", branch = "wasm_wip", default-features = false}
+nu-errors = {git = "https://github.com/jonathandturner/nushell.git", branch = "wasm_wip", default-features = false}
 
 web-sys = {version = "0.3.14", features = ["console"]}
 


### PR DESCRIPTION
Update the output we send to the website to be JSON-serialized outputs from Nu instead of just strings