### PR TITLE
build fix for rustc 1.52.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 bin/
 pkg/
 wasm-pack.log
+.DS_Store

--- a/src/open.rs
+++ b/src/open.rs
@@ -66,7 +66,7 @@ impl WholeStreamCommand for Open {
 }
 
 fn open(args: CommandArgs) -> Result<ActionStream, ShellError> {
-    let scope = args.scope.clone();
+    let scope = args.scope().clone();
     let (
         OpenArgs {
             path,


### PR DESCRIPTION
Small fix for build issue. Also added .DS_Store to the gitignore. Works with rustc 1.52.1.